### PR TITLE
feat: add support for Prisma TypedSQL ($queryRawTyped)

### DIFF
--- a/scripts/runTests.ts
+++ b/scripts/runTests.ts
@@ -32,11 +32,11 @@ const program = Effect.gen(function* () {
   if (clean) {
     yield* run(".", "tsc", "--noEmit");
   }
-  yield* run("./tests", "prisma", "generate");
-  const dbExists = yield* fs.exists("prisma/dev.db");
+  const dbExists = yield* fs.exists("tests/prisma/dev.db");
   if (clean || !dbExists) {
     yield* run("./tests", "prisma", "db", "push");
   }
+  yield* run("./tests", "prisma", "generate", "--sql");
   yield* run("./tests", "tsc", "--noEmit");
   yield* run("./tests", "vitest", "run");
 }).pipe(

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,14 @@ function generateRawSqlOperations() {
           try: () => client.$queryRawUnsafe(query, ...values),
           catch: (error) => mapError(error, "$queryRawUnsafe", "Prisma")
         }),
+      ),
+
+    $queryRawTyped: <T>(typedQuery: runtime.TypedSql<unknown[], T>) =>
+      Effect.flatMap(clientOrTx(client), client =>
+        Effect.tryPromise({
+          try: () => client.$queryRawTyped(typedQuery),
+          catch: (error) => mapError(error, "$queryRawTyped", "Prisma")
+        }),
       ),`;
 }
 
@@ -310,6 +318,7 @@ async function generateUnifiedService(
 import { Cause, Context, Data, Effect, Exit, Option, Runtime } from "effect"
 import { Service } from "effect/Effect"
 import { Prisma, PrismaClient } from "${clientImportPath}"
+import * as runtime from "@prisma/client/runtime/client"
 
 export class PrismaClientService extends Context.Tag("PrismaClientService")<
   PrismaClientService,

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -8,6 +8,7 @@ import {
   PrismaTransactionClientService,
   PrismaUniqueConstraintError,
 } from "./prisma/generated/effect";
+import { getUsersByName } from "./prisma/generated/sql";
 
 describe("Prisma Effect Generator", () => {
   const url = "file:prisma/dev.db";
@@ -238,6 +239,55 @@ describe("Prisma Effect Generator", () => {
       if (error instanceof MyCustomError) {
         expect(error.message).toBe("boom");
       }
+    }).pipe(Effect.provide(MainLayer)),
+  );
+
+  it.effect("should support $queryRawTyped with TypedSQL", () =>
+    Effect.gen(function* () {
+      const prisma = yield* PrismaService;
+      const email = `typed-sql-test-${Date.now()}@example.com`;
+
+      // Create test user
+      const user = yield* prisma.user.create({
+        data: { email, name: "TypedSQL Test User" },
+      });
+
+      // Use TypedSQL query
+      const users = yield* prisma.$queryRawTyped(
+        getUsersByName("%TypedSQL%"),
+      );
+
+      // Verify result
+      expect(users.length).toBeGreaterThan(0);
+      expect(users[0].email).toBeDefined();
+      expect(users[0].name).toContain("TypedSQL");
+
+      // Cleanup
+      yield* prisma.user.delete({ where: { id: user.id } });
+    }).pipe(Effect.provide(MainLayer)),
+  );
+
+  it.effect("should support $queryRawTyped within transactions", () =>
+    Effect.gen(function* () {
+      const prisma = yield* PrismaService;
+      const email = `tx-typed-sql-${Date.now()}@example.com`;
+
+      yield* prisma.$transaction(
+        Effect.gen(function* () {
+          yield* prisma.user.create({
+            data: { email, name: "Transaction TypedSQL User" },
+          });
+
+          const users = yield* prisma.$queryRawTyped(
+            getUsersByName("%Transaction TypedSQL%"),
+          );
+          expect(users.length).toBe(1);
+          expect(users[0].name).toBe("Transaction TypedSQL User");
+        }),
+      );
+
+      // Cleanup
+      yield* prisma.user.delete({ where: { email } });
     }).pipe(Effect.provide(MainLayer)),
   );
 });

--- a/tests/prisma/schema.prisma
+++ b/tests/prisma/schema.prisma
@@ -3,8 +3,9 @@ datasource db {
 }
 
 generator client {
-  provider = "prisma-client"
-  output   = "./generated"
+  provider        = "prisma-client"
+  output          = "./generated"
+  previewFeatures = ["typedSql"]
 }
 
 generator effect {

--- a/tests/prisma/sql/getUsersByName.sql
+++ b/tests/prisma/sql/getUsersByName.sql
@@ -1,0 +1,2 @@
+-- @param {String} $1:namePattern - Pattern to match user names
+SELECT id, email, name FROM "User" WHERE name LIKE ?


### PR DESCRIPTION
## Summary

- Adds `$queryRawTyped` method to the generated PrismaService for type-safe raw SQL queries using Prisma's TypedSQL feature
- Wraps Prisma's `$queryRawTyped` with Effect, supporting transaction context via `clientOrTx`
- Uses standard error handling pattern with `mapError`

## Test plan

- [x] Added integration test for basic `$queryRawTyped` usage
- [x] Added integration test for `$queryRawTyped` within transactions
- [x] All 10 tests pass

## Note

When using `@prisma/adapter-better-sqlite3`, SQL queries must use `?` placeholders instead of `$1` syntax. The `@param` annotation still uses `$1:name` for Prisma's type generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)