### PR TITLE
fix: generated aggregate/groupBy break for snake_case (lower-cased) model names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,11 @@ function toCamelCase(str: string) {
   return str.charAt(0).toLowerCase() + str.slice(1);
 }
 
+// Utility function to capitalize the first character (inverse of toCamelCase)
+function capitalize(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
 // The major version of `effect` the generated code targets. v3 and v4 differ in
 // their service/runtime APIs (see `variantsFor`), so the generator emits code
 // matching whichever `effect` the consuming project has installed.
@@ -160,6 +165,8 @@ function generateModelOperations(models: DMMF.Model[]) {
     .map((model) => {
       const modelName = model.name;
       const modelNameCamel = toCamelCase(modelName);
+      // Prisma capitalizes the first letter only for *AggregateArgs / *GroupByOutputType
+      const modelNameCapitalized = capitalize(modelName);
 
       return `    ${modelNameCamel}: {
       findUnique: <T extends Prisma.${modelName}FindUniqueArgs>(args: Prisma.SelectSubset<T, Prisma.${modelName}FindUniqueArgs>) =>
@@ -283,7 +290,7 @@ function generateModelOperations(models: DMMF.Model[]) {
           }),
         ),
 
-      aggregate: <T extends Prisma.${modelName}AggregateArgs>(args: Prisma.SelectSubset<T, Prisma.${modelName}AggregateArgs>) =>
+      aggregate: <T extends Prisma.${modelNameCapitalized}AggregateArgs>(args: Prisma.SelectSubset<T, Prisma.${modelNameCapitalized}AggregateArgs>) =>
         Effect.flatMap(clientOrTx(client), client =>
           Effect.tryPromise({
             try: () => client.${modelNameCamel}.aggregate(args),
@@ -352,18 +359,18 @@ function generateModelOperations(models: DMMF.Model[]) {
         Effect.flatMap(clientOrTx(client), client =>
           Effect.tryPromise({
             try: () => client.${modelNameCamel}.groupBy(args as any) as Prisma.PrismaPromise<
-              Array<Prisma.PickEnumerable<Prisma.${modelName}GroupByOutputType, T["by"]> & {
+              Array<Prisma.PickEnumerable<Prisma.${modelNameCapitalized}GroupByOutputType, T["by"]> & {
                   [P in keyof T &
-                    keyof Prisma.${modelName}GroupByOutputType]: P extends "_count"
+                    keyof Prisma.${modelNameCapitalized}GroupByOutputType]: P extends "_count"
                     ? T[P] extends boolean
                       ? number
                       : Prisma.GetScalarType<
                           T[P],
-                          Prisma.${modelName}GroupByOutputType[P]
+                          Prisma.${modelNameCapitalized}GroupByOutputType[P]
                         >
                     : Prisma.GetScalarType<
                         T[P],
-                        Prisma.${modelName}GroupByOutputType[P]
+                        Prisma.${modelNameCapitalized}GroupByOutputType[P]
                       >;
                 }>>,
             catch: (error) => mapFindError(error, "groupBy", "${modelName}")

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -106,6 +106,36 @@ describe("Prisma Effect Generator", () => {
     }).pipe(Effect.provide(MainLayer)),
   );
 
+  it.effect("should support aggregate and groupBy on a snake_case model", () =>
+    Effect.gen(function* () {
+      const prisma = yield* PrismaService;
+      yield* prisma.user_account.create({
+        data: { email: `acct-1-${Date.now()}@example.com`, score: 10 },
+      });
+      yield* prisma.user_account.create({
+        data: { email: `acct-2-${Date.now()}@example.com`, score: 20 },
+      });
+
+      const aggregate = yield* prisma.user_account.aggregate({
+        _sum: { score: true },
+        _avg: { score: true },
+      });
+      expect(aggregate._sum.score).toBe(30);
+      expect(aggregate._avg.score).toBe(15);
+
+      const grouped = yield* prisma.user_account.groupBy({
+        by: ["score"],
+        _count: true,
+        orderBy: { score: "asc" },
+      });
+      expect(grouped.length).toBe(2);
+      expect(grouped[0].score).toBe(10);
+      expect(grouped[1].score).toBe(20);
+
+      yield* prisma.user_account.deleteMany({});
+    }).pipe(Effect.provide(MainLayer)),
+  );
+
   it.effect("should support transactions", () =>
     Effect.gen(function* () {
       const prisma = yield* PrismaService;

--- a/tests/prisma/schema.prisma
+++ b/tests/prisma/schema.prisma
@@ -28,3 +28,10 @@ model Post {
   authorId Int
   author   User    @relation(fields: [authorId], references: [id])
 }
+
+// snake_case model name: regression coverage for first-letter-capitalized Prisma types
+model user_account {
+  id    Int    @id @default(autoincrement())
+  email String @unique
+  score Int    @default(0)
+}


### PR DESCRIPTION
## Problem

For any model whose name starts with a **lower-case letter** (e.g. snake_case schemas like `user_account`), the generated `effect.ts` does not typecheck. The `aggregate` and `groupBy` operations reference Prisma types that don't exist:

```
prisma/generated/effect.ts: error TS2724: '…/prismaNamespace' has no exported member
  named 'user_accountAggregateArgs'. Did you mean 'User_accountAggregateArgs'?
prisma/generated/effect.ts: error TS2724: '…/prismaNamespace' has no exported member
  named 'user_accountGroupByOutputType'. Did you mean 'User_accountGroupByOutputType'?
```

Because the whole service is emitted as one file, this makes the entire generated module fail to compile.

## Root cause

Prisma uses the **verbatim** model name for most generated types (`<name>FindManyArgs`, `<name>CreateArgs`, `<name>GroupByArgs`, the delegate accessor, …) but **capitalizes the first letter** for exactly two of them: `<Name>AggregateArgs` and `<Name>GroupByOutputType`.

The generator emitted `Prisma.${model.name}…` for *all* type references, so it got the first-letter-capitalized ones wrong. This is invisible for PascalCase models (`User`) because capitalizing an already-capitalized name is a no-op — which is why the existing `User`/`Post` fixtures never caught it.

## Fix

Add a `capitalize` helper and use it for **only** the `AggregateArgs` and `GroupByOutputType` references (the `GroupByArgs` references stay verbatim). It's a no-op for PascalCase models, so existing schemas are unaffected.

## Tests

Added a snake_case `user_account` model to the test fixtures. This exercises:
- **compile-time**: the existing `tsc --noEmit` step over the generated file (fails on `main`, passes here)
- **runtime**: a new test calling `prisma.user_account.aggregate(...)` and `prisma.user_account.groupBy(...)`

Full suite green (13 tests). Without the fix the new fixture reproduces the `TS2724` errors above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)