### PR TITLE
feat: support extended clients via layerFromPrismaClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,29 @@ const PrismaLayer = Layer.provide(
 );
 ```
 
+#### Extended clients (`$extends`)
+
+A client created with `client.$extends(...)` — for example with
+`@prisma/extension-accelerate` — has a static type that is not assignable to
+`PrismaClient`, so `Layer.succeed(PrismaClientService, extended)` does not
+typecheck. Use the generated `layerFromPrismaClient` instead, which accepts
+plain and extended clients:
+
+```typescript
+import { PrismaService, layerFromPrismaClient } from "~prisma/effect";
+import { withAccelerate } from "@prisma/extension-accelerate";
+
+const prisma = new PrismaClient().$extends(withAccelerate());
+const PrismaLayer = Layer.provide(
+  PrismaService.Default, // on Effect v4, use PrismaService.layer
+  layerFromPrismaClient(prisma),
+);
+```
+
+At runtime all operations go through the extended client and behave per the
+extension. Note that an extension's type-level changes (such as result
+extensions adding computed fields) are not reflected in the service's types.
+
 ### 2. Use the Service
 
 Access the `PrismaService` in your Effect programs.

--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ in the service's types:
   the extended client directly (keep your own reference to it) for those
   queries.
 
-Also note that `PrismaClientService` is typed as `PrismaClientLike`, the
-structural subset of the client the service actually uses. Lifecycle methods
-such as `$disconnect()` are not part of that surface — call them on the
-client you constructed rather than on the service.
+`PrismaClientService` stays typed as `PrismaClient`, so lifecycle methods
+(`$disconnect()`, batch `$transaction`, ...) remain available through the
+service — extensions wrap the client rather than stripping it, so these work
+on extended clients too.
 
 ### 2. Use the Service
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,11 @@ in the service's types:
   queries.
 
 `PrismaClientService` stays typed as `PrismaClient`, so lifecycle methods
-(`$disconnect()`, batch `$transaction`, ...) remain available through the
-service — extensions wrap the client rather than stripping it, so these work
-on extended clients too.
+remain available through the service — `$connect()`, `$disconnect()`, and
+batch `$transaction` all exist on extended clients too. The one exception is
+`$on`: Prisma strips event listening from extended clients, so call `$on` on
+the base client *before* `$extends` (per Prisma's own guidance) rather than
+through the service when it was provided an extended client.
 
 ### 2. Use the Service
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,21 @@ const PrismaLayer = Layer.provide(
 ```
 
 At runtime all operations go through the extended client and behave per the
-extension. Note that an extension's type-level changes (such as result
-extensions adding computed fields) are not reflected in the service's types.
+extension. Note that an extension's type-level changes are **not** reflected
+in the service's types:
+
+- Result extensions' computed fields don't appear on the service's return
+  types.
+- Extension-specific query arguments are rejected by the service's typed
+  methods — for Accelerate that means per-query caching config such as
+  `cacheStrategy` cannot be passed through the service without a cast; use
+  the extended client directly (keep your own reference to it) for those
+  queries.
+
+Also note that `PrismaClientService` is typed as `PrismaClientLike`, the
+structural subset of the client the service actually uses. Lifecycle methods
+such as `$disconnect()` are not part of that surface — call them on the
+client you constructed rather than on the service.
 
 ### 2. Use the Service
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -514,9 +514,10 @@ export class PrismaClientService extends ${v.tag("PrismaClientService", "PrismaC
 
 // A client created with client.$extends(...) (e.g. @prisma/extension-accelerate).
 // Its static type is not structurally compatible with PrismaClient — extended
-// delegates use different generic signatures — but at runtime an extension
-// wraps the client rather than stripping it, so every operation this service
-// uses (and the lifecycle methods) remain available. Requiring every model
+// delegates use different generic signatures — but at runtime every operation
+// this service uses remains available, as do $connect/$disconnect and batch
+// $transaction. The exception is $on, which Prisma strips from extended
+// clients (call it on the base client before $extends). Requiring every model
 // delegate property (via TypeMap) makes a client generated from a different
 // schema, or an incomplete mock, a compile error, while still accepting any
 // extension of this schema's client.

--- a/src/index.ts
+++ b/src/index.ts
@@ -508,35 +508,18 @@ async function generateUnifiedService(
 
   const serviceContent = `${headerFor(noCheck)}
 ${v.imports}
-import { Prisma } from "${clientImportPath}"${runtimeImport}
+import { Prisma, PrismaClient } from "${clientImportPath}"${runtimeImport}
 
-// The structural subset of PrismaClient that the generated service uses.
-// Requiring only this (rather than PrismaClient itself) allows extended
-// clients created with client.$extends(...) — e.g. @prisma/extension-accelerate
-// — to be provided as well: their type drops $on/$use, which this service
-// never calls. $transaction is redeclared with only the interactive form the
-// service invokes, because the batch overload's signature differs between the
-// base and extended client types and would fail structural matching.
-export type PrismaClientLike = Omit<Prisma.TransactionClient, "$transaction"> & {
-  $transaction<R>(
-    fn: (tx: Prisma.TransactionClient) => Promise<R>,
-    options?: {
-      maxWait?: number
-      timeout?: number
-      isolationLevel?: Prisma.TransactionIsolationLevel
-    },
-  ): Promise<R>
-}
-
-export class PrismaClientService extends ${v.tag("PrismaClientService", "PrismaClientLike")} {}
+export class PrismaClientService extends ${v.tag("PrismaClientService", "PrismaClient")} {}
 
 // A client created with client.$extends(...) (e.g. @prisma/extension-accelerate).
 // Its static type is not structurally compatible with PrismaClient — extended
-// delegates use different generic signatures — but at runtime it supports every
-// operation this service uses. Requiring every model delegate property (via
-// TypeMap) makes a client generated from a different schema, or an incomplete
-// mock, a compile error, while still accepting any extension of this schema's
-// client.
+// delegates use different generic signatures — but at runtime an extension
+// wraps the client rather than stripping it, so every operation this service
+// uses (and the lifecycle methods) remain available. Requiring every model
+// delegate property (via TypeMap) makes a client generated from a different
+// schema, or an incomplete mock, a compile error, while still accepting any
+// extension of this schema's client.
 export type ExtendedPrismaClientLike = {
   $transaction(...args: ReadonlyArray<any>): Promise<any>
   $queryRaw(...args: ReadonlyArray<any>): Promise<any>
@@ -546,12 +529,14 @@ export type ExtendedPrismaClientLike = {
 }
 
 // Builds the PrismaClientService layer from a plain or extended client (#17).
-// Note: an extension's type-level changes (e.g. result extensions adding
-// computed fields) are not reflected in the service's types; at runtime all
-// operations go through the extended client and behave per the extension.
+// The cast is sound at runtime (see ExtendedPrismaClientLike above), but an
+// extension's type-level changes (e.g. result extensions adding computed
+// fields, or extra query args like Accelerate's cacheStrategy) are not
+// reflected in the service's types; at runtime all operations go through the
+// extended client and behave per the extension.
 export const layerFromPrismaClient = (
-  client: PrismaClientLike | ExtendedPrismaClientLike,
-) => Layer.succeed(PrismaClientService, client as PrismaClientLike)
+  client: PrismaClient | ExtendedPrismaClientLike,
+) => Layer.succeed(PrismaClientService, client as PrismaClient)
 
 export class PrismaTransactionClientService extends ${v.tag("PrismaTransactionClientService", "Prisma.TransactionClient")} {}
 
@@ -898,7 +883,7 @@ const mapUpdateManyError = (error: unknown, operation: string, model: string): P
   throw error;
 }
 
-const clientOrTx = (client: PrismaClientLike) => Effect.map(
+const clientOrTx = (client: PrismaClient) => Effect.map(
   Effect.serviceOption(PrismaTransactionClientService),
   Option.getOrElse(() => client),
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -462,7 +462,7 @@ function variantsFor(major: EffectMajor) {
   if (major === 3) {
     return {
       imports:
-        `import { Cause, Context, Data, Effect, Exit, Option, Runtime } from "effect"\n` +
+        `import { Cause, Context, Data, Effect, Exit, Layer, Option, Runtime } from "effect"\n` +
         `import { Service } from "effect/Effect"`,
       tag: (self: string, type: string, id: string = self) =>
         `Context.Tag("${id}")<\n  ${self},\n  ${type}\n>()`,
@@ -508,9 +508,45 @@ async function generateUnifiedService(
 
   const serviceContent = `${headerFor(noCheck)}
 ${v.imports}
-import { Prisma, PrismaClient } from "${clientImportPath}"${runtimeImport}
+import { Prisma } from "${clientImportPath}"${runtimeImport}
 
-export class PrismaClientService extends ${v.tag("PrismaClientService", "PrismaClient")} {}
+// The structural subset of PrismaClient that the generated service uses.
+// Requiring only this (rather than PrismaClient itself) allows extended
+// clients created with client.$extends(...) — e.g. @prisma/extension-accelerate
+// — to be provided as well: their type drops $on/$use, which this service
+// never calls. $transaction is redeclared with only the interactive form the
+// service invokes, because the batch overload's signature differs between the
+// base and extended client types and would fail structural matching.
+export type PrismaClientLike = Omit<Prisma.TransactionClient, "$transaction"> & {
+  $transaction<R>(
+    fn: (tx: Prisma.TransactionClient) => Promise<R>,
+    options?: {
+      maxWait?: number
+      timeout?: number
+      isolationLevel?: Prisma.TransactionIsolationLevel
+    },
+  ): Promise<R>
+}
+
+export class PrismaClientService extends ${v.tag("PrismaClientService", "PrismaClientLike")} {}
+
+// A client created with client.$extends(...) (e.g. @prisma/extension-accelerate).
+// Its static type is not structurally compatible with PrismaClient — extended
+// delegates use different generic signatures — but at runtime it supports every
+// operation this service uses. Only a minimal shape is required here.
+export interface ExtendedPrismaClientLike {
+  $transaction(...args: ReadonlyArray<any>): Promise<any>
+  $queryRaw(...args: ReadonlyArray<any>): Promise<any>
+  $executeRaw(...args: ReadonlyArray<any>): Promise<any>
+}
+
+// Builds the PrismaClientService layer from a plain or extended client (#17).
+// Note: an extension's type-level changes (e.g. result extensions adding
+// computed fields) are not reflected in the service's types; at runtime all
+// operations go through the extended client and behave per the extension.
+export const layerFromPrismaClient = (
+  client: PrismaClientLike | ExtendedPrismaClientLike,
+) => Layer.succeed(PrismaClientService, client as PrismaClientLike)
 
 export class PrismaTransactionClientService extends ${v.tag("PrismaTransactionClientService", "Prisma.TransactionClient")} {}
 
@@ -857,7 +893,7 @@ const mapUpdateManyError = (error: unknown, operation: string, model: string): P
   throw error;
 }
 
-const clientOrTx = (client: PrismaClient) => Effect.map(
+const clientOrTx = (client: PrismaClientLike) => Effect.map(
   Effect.serviceOption(PrismaTransactionClientService),
   Option.getOrElse(() => client),
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -533,11 +533,16 @@ export class PrismaClientService extends ${v.tag("PrismaClientService", "PrismaC
 // A client created with client.$extends(...) (e.g. @prisma/extension-accelerate).
 // Its static type is not structurally compatible with PrismaClient — extended
 // delegates use different generic signatures — but at runtime it supports every
-// operation this service uses. Only a minimal shape is required here.
-export interface ExtendedPrismaClientLike {
+// operation this service uses. Requiring every model delegate property (via
+// TypeMap) makes a client generated from a different schema, or an incomplete
+// mock, a compile error, while still accepting any extension of this schema's
+// client.
+export type ExtendedPrismaClientLike = {
   $transaction(...args: ReadonlyArray<any>): Promise<any>
   $queryRaw(...args: ReadonlyArray<any>): Promise<any>
   $executeRaw(...args: ReadonlyArray<any>): Promise<any>
+} & {
+  [K in Prisma.TypeMap["meta"]["modelProps"]]: unknown
 }
 
 // Builds the PrismaClientService layer from a plain or extended client (#17).

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -441,7 +441,7 @@ describe("Prisma Effect Generator", () => {
       $executeRaw: async () => undefined,
     };
     // @ts-expect-error — lacks the model delegate properties (user, post, ...),
-    // so it satisfies neither PrismaClientLike nor ExtendedPrismaClientLike.
+    // so it satisfies neither PrismaClient nor ExtendedPrismaClientLike.
     const layer = layerFromPrismaClient(wrongShapeClient);
     expect(layer).toBeDefined();
   });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -4,6 +4,7 @@ import { Data, Effect, Layer } from "effect";
 import * as fs from "fs";
 import { PrismaClient } from "./prisma/generated/client";
 import {
+  layerFromPrismaClient,
   PrismaClientService,
   PrismaService,
   PrismaTransactionClientService,
@@ -386,5 +387,50 @@ describe("Prisma Effect Generator", () => {
       const count = yield* prisma.embedding.count({});
       expect(count).toBe(0);
     }).pipe(Effect.provide(MainLayer)),
+  );
+
+  it.effect("should accept an extended client ($extends)", () =>
+    Effect.gen(function* () {
+      const prisma = yield* PrismaService;
+      const email = `extended-${Date.now()}@example.com`;
+
+      const user = yield* prisma.user.create({
+        data: { email, name: "Extended User" },
+      });
+      expect(user.email).toBe(email);
+
+      // Transactions must work through the extended client too.
+      yield* prisma.$transaction(
+        prisma.user.update({
+          where: { id: user.id },
+          data: { name: "Extended User 2" },
+        }),
+      );
+      const found = yield* prisma.user.findUniqueOrThrow({
+        where: { id: user.id },
+      });
+      expect(found.name).toBe("Extended User 2");
+
+      yield* prisma.user.delete({ where: { id: user.id } });
+    }).pipe(
+      Effect.provide(
+        Layer.provide(
+          (layer ?? Default)!,
+          // Extended clients have type DynamicClientExtensionThis, which is
+          // not assignable to PrismaClient; layerFromPrismaClient must accept
+          // one without casts on the consumer side (#17).
+          layerFromPrismaClient(
+            prisma.$extends({
+              name: "test-extension",
+              query: {
+                $allModels: {
+                  $allOperations: ({ args, query }) => query(args),
+                },
+              },
+            }),
+          ),
+        ),
+      ),
+    ),
   );
 });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -433,4 +433,16 @@ describe("Prisma Effect Generator", () => {
       ),
     ),
   );
+
+  it("should reject clients missing this schema's model delegates at compile time", () => {
+    const wrongShapeClient = {
+      $transaction: async () => undefined,
+      $queryRaw: async () => undefined,
+      $executeRaw: async () => undefined,
+    };
+    // @ts-expect-error — lacks the model delegate properties (user, post, ...),
+    // so it satisfies neither PrismaClientLike nor ExtendedPrismaClientLike.
+    const layer = layerFromPrismaClient(wrongShapeClient);
+    expect(layer).toBeDefined();
+  });
 });


### PR DESCRIPTION
Closes #17.

An `$extends`-ed client (e.g. `@prisma/extension-accelerate`) has type `DynamicClientExtensionThis`, which is not assignable to `PrismaClient` — so providing one to `PrismaClientService` fails to typecheck.

**Why not a structural subset:** typing the service against only the surface it uses fails at two levels (verified against Prisma 7.8's generated types): `TransactionClient`'s `$transaction` overloads reference the concrete client type on both sides, and extended *delegates* use different generics (`Exact` args, fluent returns) that are mutually unassignable with base delegates — while loosening them would collapse consumer typing. An earlier revision of this PR shipped such a subset (`PrismaClientLike`) anyway as the tag type, but that narrowed the public surface (`$disconnect`, batch `$transaction`) for existing consumers; since `$extends` *wraps* the client rather than stripping it, those methods exist on extended clients at runtime too, so the narrowing bought type-honesty at the price of a breaking change. Reverted: **the tag stays `PrismaClient`; zero type changes for existing consumers.**

**What this does:**
- New `layerFromPrismaClient(client)` accepts a plain `PrismaClient` **or** an `ExtendedPrismaClientLike` — a minimal structural bound that also requires every model delegate property (via `Prisma.TypeMap["meta"]["modelProps"]`), so a client generated from a different schema or an incomplete mock is a compile error. It builds the `PrismaClientService` layer, containing the one unavoidable cast at a sanctioned, documented boundary.
- Documented limitations (README): result-extension computed fields don't appear in the service's return types; extension-specific query args (e.g. Accelerate's `cacheStrategy`) are rejected by the typed methods — use the extended client directly for those queries. At runtime all operations go through the extended client and behave per the extension.

**Tests:** integration test provides a real `$extends`-ed client through `layerFromPrismaClient` — the call itself is the compile-time regression test (fails on main) — plus runtime create/interactive-transaction/find/delete through it, and a `ts-expect-error` test pinning rejection of wrong-shape clients. Full suite 19/19 on both effect legs.