### PR TITLE
ci: fail CI when files are not prettier-formatted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  format:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -24,6 +24,9 @@ jobs:
 
       - name: Check formatting
         run: npm run format:check
+
+      - name: Lint
+        run: npm run lint
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,25 @@ on:
   pull_request:
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check
+
   test:
     runs-on: ubuntu-latest
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
 CHANGELOG.md
+dist/
+**/generated/

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ in the service's types:
 remain available through the service — `$connect()`, `$disconnect()`, and
 batch `$transaction` all exist on extended clients too. The one exception is
 `$on`: Prisma strips event listening from extended clients, so call `$on` on
-the base client *before* `$extends` (per Prisma's own guidance) rather than
+the base client _before_ `$extends` (per Prisma's own guidance) rather than
 through the service when it was provided an extended client.
 
 ### 2. Use the Service

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "tsc && chmod +x dist/index.js",
     "test": "tsx scripts/runTests.ts",
     "format": "prettier --write . && eslint . --fix",
+    "format:check": "prettier --check .",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "tsx scripts/runTests.ts",
     "format": "prettier --write . && eslint . --fix",
     "format:check": "prettier --check .",
+    "lint": "eslint .",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -22,8 +22,12 @@ describe("Prisma Effect Generator", () => {
     layer?: Layer.Layer<PrismaService, never, PrismaClientService>;
     Default?: Layer.Layer<PrismaService, never, PrismaClientService>;
   };
+  const serviceLayer = layer ?? Default;
+  if (serviceLayer === undefined) {
+    throw new Error("PrismaService exposes neither .layer nor .Default");
+  }
   const MainLayer = Layer.provide(
-    (layer ?? Default)!,
+    serviceLayer,
     Layer.succeed(PrismaClientService, prisma),
   );
 
@@ -422,7 +426,7 @@ describe("Prisma Effect Generator", () => {
     }).pipe(
       Effect.provide(
         Layer.provide(
-          (layer ?? Default)!,
+          serviceLayer,
           // Extended clients have type DynamicClientExtensionThis, which is
           // not assignable to PrismaClient; layerFromPrismaClient must accept
           // one without casts on the consumer side (#17).

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -313,9 +313,7 @@ describe("Prisma Effect Generator", () => {
       });
 
       // Use TypedSQL query
-      const users = yield* prisma.$queryRawTyped(
-        getUsersByName("%TypedSQL%"),
-      );
+      const users = yield* prisma.$queryRawTyped(getUsersByName("%TypedSQL%"));
 
       // Verify result
       expect(users.length).toBeGreaterThan(0);
@@ -354,13 +352,20 @@ describe("Prisma Effect Generator", () => {
   it("should include $queryRawTyped when typedSql preview feature is enabled", () => {
     const generated = fs.readFileSync("prisma/generated/effect.ts", "utf-8");
     expect(generated).toContain("$queryRawTyped");
-    expect(generated).toContain('import * as runtime from "@prisma/client/runtime/client"');
+    expect(generated).toContain(
+      'import * as runtime from "@prisma/client/runtime/client"',
+    );
   });
 
   it("should not include $queryRawTyped when typedSql preview feature is not enabled", () => {
-    const generated = fs.readFileSync("no-typedsql/generated/effect.ts", "utf-8");
+    const generated = fs.readFileSync(
+      "no-typedsql/generated/effect.ts",
+      "utf-8",
+    );
     expect(generated).not.toContain("$queryRawTyped");
-    expect(generated).not.toContain('import * as runtime from "@prisma/client/runtime/client"');
+    expect(generated).not.toContain(
+      'import * as runtime from "@prisma/client/runtime/client"',
+    );
   });
 
   it("should omit create operations for models with a required Unsupported field", () => {
@@ -379,14 +384,16 @@ describe("Prisma Effect Generator", () => {
     expect(generated).toContain("client.user.create");
   });
 
-  it.effect("should read and aggregate a model with a required Unsupported field", () =>
-    Effect.gen(function* () {
-      const prisma = yield* PrismaService;
-      const rows = yield* prisma.embedding.findMany({});
-      expect(rows).toEqual([]);
-      const count = yield* prisma.embedding.count({});
-      expect(count).toBe(0);
-    }).pipe(Effect.provide(MainLayer)),
+  it.effect(
+    "should read and aggregate a model with a required Unsupported field",
+    () =>
+      Effect.gen(function* () {
+        const prisma = yield* PrismaService;
+        const rows = yield* prisma.embedding.findMany({});
+        expect(rows).toEqual([]);
+        const count = yield* prisma.embedding.count({});
+        expect(count).toBe(0);
+      }).pipe(Effect.provide(MainLayer)),
   );
 
   it.effect("should accept an extended client ($extends)", () =>


### PR DESCRIPTION
Adds a `lint` job to CI that runs `prettier --check .` and `eslint .` (via new `format:check` and `lint` scripts), extends `.prettierignore` with `dist/` and `**/generated/`, formats the two files on `main` that were not prettier-clean (`README.md`, `tests/integration.test.ts`), and fixes the two pre-existing `no-non-null-assertion` errors in the integration test by replacing `(layer ?? Default)!` with a checked variable.

Verified both paths on this branch: a deliberately unformatted commit made the job fail (run 28952055769), and the current head passes all jobs.