### PR TITLE
ci: add dependabot config and pin actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Development-only updates: devDependencies and pinned GitHub Actions are
+# build/test tooling that consumers never install. Runtime `dependencies` and
+# `peerDependencies` ranges are consumer-facing and managed manually, so their
+# floors are only raised deliberately.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,15 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "development"
+    # Only propose versions that have been public for a while, so compromised
+    # releases can be flagged and pulled before they reach this repo.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
           cache: "npm"
@@ -58,10 +58,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
           cache: "npm"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
           release-type: node
@@ -22,11 +22,11 @@ jobs:
       # The following steps only run when a release was actually created
       - name: Checkout
         if: ${{ steps.release.outputs.release_created }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
         if: ${{ steps.release.outputs.release_created }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Refuse to resolve package versions published fewer than 7 days ago
+# (supply-chain cooldown; npm >= 11.10 — older npm warns and ignores it).
+# Matches the dependabot cooldown in .github/dependabot.yml.
+min-release-age=7


### PR DESCRIPTION
Follow-up to #37 — dependency-update hygiene and supply-chain hardening.

- **`.github/dependabot.yml`** (new): weekly updates for `devDependencies` (`allow: dependency-type: development`) and GitHub Actions. Runtime `dependencies` and `peerDependencies` are deliberately excluded — those ranges are consumer-facing, so their version floors stay manually managed and are only raised when actually needed.
- **Dependabot cooldown**: new versions must be public for 7 days (14 for major bumps) before dependabot proposes them, giving compromised releases time to be flagged and pulled first.
- **`.npmrc`** (new): `min-release-age=7` applies the same 7-day quarantine to local installs by contributors and to CI, independent of user config. Requires npm 11.10+ (older npm warns and ignores the key); not shipped to consumers (`files` is `dist` + `README.md`).
- **`ci.yml` / `release-please.yml`**: pin all actions to commit SHAs. SHAs verified against the exact release tags: `actions/checkout` v4.3.1, `actions/setup-node` v4.4.0, `googleapis/release-please-action` v4.4.1. Dependabot keeps these pins updated (it bumps the SHA and the version comment together).

Verified: `prettier --check .` and `eslint .` clean locally; CI green on the pinned actions and with the cooldown npmrc in effect; GitHub's dependabot.yml validation check passes.