### PR TITLE
ci: align release Node with CI, test before publish, add beta canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -39,6 +40,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     # The generator emits different code for effect v3 vs v4. Run the full
     # integration suite against both: root deps (incl. the test harness) stay

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
 
     steps:
       - name: Checkout code
@@ -40,7 +40,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     # The generator emits different code for effect v3 vs v4. Run the full
     # integration suite against both: root deps (incl. the test harness) stay

--- a/.github/workflows/effect-beta.yml
+++ b/.github/workflows/effect-beta.yml
@@ -1,0 +1,41 @@
+name: effect-beta canary
+
+# Non-blocking canary: the CI matrix pins an effect v4 beta that silently ages,
+# so run the suite against the latest beta weekly to surface upstream breakage
+# before a user reports it. Failures notify but never block PRs.
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install test fixtures (effect@beta)
+        # Same single-vitest-instance setup as the CI test matrix. The repo
+        # .npmrc quarantines fresh releases; this canary exists to test them,
+        # so lift the cooldown for this install only.
+        env:
+          NPM_CONFIG_MIN_RELEASE_AGE: "0"
+        run: cd tests && npm install --no-save --no-package-lock --legacy-peer-deps effect@beta @effect/vitest@beta
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/effect-beta.yml
+++ b/.github/workflows/effect-beta.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,9 +10,16 @@ permissions:
   pull-requests: write
   id-token: write # Required for npm provenance
 
+# Serialize runs so two pushes to main can't race on the release PR or publish
+# twice; never cancel a run that may already be publishing.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
@@ -28,7 +35,9 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "lts/*"
+          # Same version CI tests on, so the published artifact is built on a
+          # Node the test suite has actually run against.
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
@@ -38,6 +47,12 @@ jobs:
       - name: Build
         if: ${{ steps.release.outputs.release_created }}
         run: npm run build
+
+      # Last line of defense: never publish a build the test suite hasn't
+      # passed on, even if a red main slipped through.
+      - name: Test
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm test
 
       - name: Publish to npm
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Final round of the CI follow-ups (after #37 and #38).

- **`release-please.yml`**: build the release on Node 24 — the same version CI tests against — instead of `lts/*`, so the published artifact is built on a Node the suite has actually run on. Run `npm test` (full pipeline: build → prisma generate → tsc → vitest) before `npm publish` as a last line of defense against publishing from a red main. Serialize the workflow with a non-cancelling `concurrency` group so two pushes to main can't race the release PR or publish twice.
- **`effect-beta.yml`** (new): weekly non-blocking canary (plus `workflow_dispatch`) running the suite against `effect@beta` / `@effect/vitest``@beta`. The CI matrix pins `4.0.0-beta.83` while upstream is already at beta.94, so this surfaces upstream breakage before the pin ages into it. The step lifts the repo's 7-day npm cooldown (`NPM_CONFIG_MIN_RELEASE_AGE: 0`) — testing fresh releases is the point of a canary.
- **Job timeouts** on all workflows (10–15 min) so a hung install can't burn the 6-hour default.

Verified: `prettier --check .` and `eslint .` clean; `effect@beta` fixture install dry-run resolves (beta.94). The canary can be smoke-tested post-merge via workflow_dispatch.