### PR TITLE
chore: bump effect v4 pins from beta.83 to beta.93

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
             effect: "^3.19"
             vitest: "^0.27"
           - name: effect-v4
-            effect: "4.0.0-beta.83"
-            vitest: "4.0.0-beta.83"
+            effect: "4.0.0-beta.93"
+            vitest: "4.0.0-beta.93"
 
     name: test (${{ matrix.name }})
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,10 @@
         "effect-prisma-generator": "dist/index.js"
       },
       "devDependencies": {
-        "@effect/platform-node": "4.0.0-beta.83",
+        "@effect/platform-node": "4.0.0-beta.93",
         "@eslint/js": "^9.39.1",
         "@types/node": "^24.10.1",
-        "effect": "4.0.0-beta.83",
+        "effect": "4.0.0-beta.93",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",
         "prettier": "3.7.1",
@@ -35,13 +35,13 @@
       }
     },
     "node_modules/@effect/platform-node": {
-      "version": "4.0.0-beta.83",
-      "resolved": "https://registry.npmjs.org/@effect/platform-node/-/platform-node-4.0.0-beta.83.tgz",
-      "integrity": "sha512-RmpVGu/+X/Bif3/g1Rzj8oFzTOknoVB3yHCa0b179vytPpKe+Kj9ZwKNcAnKWqHUDkbSPBq1Ca60mvOHr2/+LQ==",
+      "version": "4.0.0-beta.93",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node/-/platform-node-4.0.0-beta.93.tgz",
+      "integrity": "sha512-QagsCGR0ZOXaCQqS5qGR2mcDng4LiP2bYhiiX1D6UC8cT9vsusVVOHiJWn8CupeDx+yVnPcu81QmA/SDt6GM1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@effect/platform-node-shared": "^4.0.0-beta.83",
+        "@effect/platform-node-shared": "^4.0.0-beta.93",
         "mime": "^4.1.0",
         "undici": "^8.2.0"
       },
@@ -49,14 +49,14 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "effect": "^4.0.0-beta.83",
+        "effect": "^4.0.0-beta.93",
         "ioredis": "^5.7.0"
       }
     },
     "node_modules/@effect/platform-node-shared": {
-      "version": "4.0.0-beta.83",
-      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-beta.83.tgz",
-      "integrity": "sha512-+yr/+PJmKTgmJq1QOINSBPgLu7Cjc4CZcotBXnGjyDEizOmimFgTkN2B8PBJAKIKUWYWfobjXqC+58/VhhPKAw==",
+      "version": "4.0.0-beta.93",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-beta.93.tgz",
+      "integrity": "sha512-XUqZ2u5GglBqY8q2jj4Q7GjN5K/enedk8auZM9rY/l5a/myaQTrQp3QnvpIK4/Yg0WFjLGuctGPMKWRk3OLIrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -67,7 +67,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "effect": "^4.0.0-beta.83"
+        "effect": "^4.0.0-beta.93"
       }
     },
     "node_modules/@electric-sql/pglite": {
@@ -2555,9 +2555,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.83",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
-      "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
+      "version": "4.0.0-beta.93",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.93.tgz",
+      "integrity": "sha512-wNS5MKFa3C42uBfIDik2oJ78lhpoYz2hN4oBR0229BeeDCIrkg/FiOvoiPGdCVlWa7MEKxEL5I0f8AILVHSD9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3836,9 +3836,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
-      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.1.tgz",
+      "integrity": "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==",
       "dev": true,
       "funding": [
         {
@@ -4232,9 +4232,9 @@
       }
     },
     "node_modules/toml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
-      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.2.tgz",
+      "integrity": "sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4352,9 +4352,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "prisma": "^7.0.0"
   },
   "devDependencies": {
-    "@effect/platform-node": "4.0.0-beta.83",
+    "@effect/platform-node": "4.0.0-beta.93",
     "@eslint/js": "^9.39.1",
     "@types/node": "^24.10.1",
-    "effect": "4.0.0-beta.83",
+    "effect": "4.0.0-beta.93",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "3.7.1",

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "description": "Integration test fixtures for effect-prisma-generator. The effect / @effect/vitest versions here are swapped by CI to exercise the generator against both effect v3 and v4. The vitest/tsc/prisma binaries come from the root package.",
   "devDependencies": {
-    "@effect/vitest": "4.0.0-beta.83",
+    "@effect/vitest": "4.0.0-beta.93",
     "@prisma/adapter-better-sqlite3": "^7.8.0",
     "@prisma/client": "^7.8.0",
-    "effect": "4.0.0-beta.83"
+    "effect": "4.0.0-beta.93"
   }
 }


### PR DESCRIPTION
Bumps the effect v4 beta pinned in the CI matrix, root devDependencies, and tests/ from `4.0.0-beta.83` to `4.0.0-beta.93`.

Why not beta.94 (the current `beta` dist-tag): it was published 2026-07-07, which is inside the repo's 7-day package cooldown — the `.npmrc` `min-release-age=7` would (correctly) refuse to install it, locally and on the runners. beta.93 (2026-07-01) is the newest version the policy allows. The weekly canary keeps testing the newest beta regardless, with the cooldown deliberately lifted.

Verified locally with a fresh `tests/node_modules`: full pipeline passes, 20/20 tests.