### PR TITLE
feat: client-generic service for extended-client type fidelity (makePrismaService + definePrismaService)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,16 +129,41 @@ const PrismaLayer = Layer.provide(
 ```
 
 At runtime all operations go through the extended client and behave per the
-extension. Note that an extension's type-level changes are **not** reflected
-in the service's types:
+extension. This route keeps the default `PrismaService`, so the service's
+types stay the **base** types — an extension's type-level changes (result
+extensions' computed fields, extension-specific args like Accelerate's
+`cacheStrategy`) are not reflected. Use `layerFromPrismaClient` when you want
+the extended client's runtime behavior but don't need its types through the
+service.
 
-- Result extensions' computed fields don't appear on the service's return
-  types.
-- Extension-specific query arguments are rejected by the service's typed
-  methods — for Accelerate that means per-query caching config such as
-  `cacheStrategy` cannot be passed through the service without a cast; use
-  the extended client directly (keep your own reference to it) for those
-  queries.
+##### Full type fidelity (`makePrismaService`)
+
+To get the extended client's **types** through the service — computed result
+fields, extension args — build the service from your client with
+`makePrismaService` and expose it under your own tag typed to that client:
+
+```typescript
+import { Context, Effect, Layer } from "effect";
+import { makePrismaService } from "~prisma/effect";
+
+const prisma = new PrismaClient().$extends(withAccelerate());
+type PrismaOps = ReturnType<typeof makePrismaService<typeof prisma>>;
+
+// One tag, typed to your specific client (Effect v4 shown; on v3 use
+// Context.Tag / Effect.Service the same way).
+class Prisma extends Context.Service<Prisma, PrismaOps>()("Prisma") {}
+const PrismaLayer = Layer.succeed(Prisma, makePrismaService(prisma));
+
+const program = Effect.gen(function* () {
+  const db = yield* Prisma;
+  // computed result fields from the extension are visible here
+  return yield* db.user.findMany({ select: { id: true } });
+});
+```
+
+`makePrismaService` is generic over the client type, so a plain `PrismaClient`
+yields exactly the base types (identical to the default `PrismaService`) and an
+extended client yields its extended types.
 
 `PrismaClientService` stays typed as `PrismaClient`, so lifecycle methods
 remain available through the service — `$connect()`, `$disconnect()`, and

--- a/README.md
+++ b/README.md
@@ -136,23 +136,20 @@ extensions' computed fields, extension-specific args like Accelerate's
 the extended client's runtime behavior but don't need its types through the
 service.
 
-##### Full type fidelity (`makePrismaService`)
+##### Full type fidelity (`definePrismaService`)
 
 To get the extended client's **types** through the service — computed result
-fields, extension args — build the service from your client with
-`makePrismaService` and expose it under your own tag typed to that client:
+fields, extension args — use `definePrismaService`, which builds a service tag
+and layer for your specific client type in one step:
 
 ```typescript
-import { Context, Effect, Layer } from "effect";
-import { makePrismaService } from "~prisma/effect";
+import { Effect } from "effect";
+import { definePrismaService } from "~prisma/effect";
 
 const prisma = new PrismaClient().$extends(withAccelerate());
-type PrismaOps = ReturnType<typeof makePrismaService<typeof prisma>>;
 
-// One tag, typed to your specific client (Effect v4 shown; on v3 use
-// Context.Tag / Effect.Service the same way).
-class Prisma extends Context.Service<Prisma, PrismaOps>()("Prisma") {}
-const PrismaLayer = Layer.succeed(Prisma, makePrismaService(prisma));
+const { service: Prisma, layer } = definePrismaService<typeof prisma>();
+const PrismaLayer = layer(prisma);
 
 const program = Effect.gen(function* () {
   const db = yield* Prisma;
@@ -161,9 +158,16 @@ const program = Effect.gen(function* () {
 });
 ```
 
-`makePrismaService` is generic over the client type, so a plain `PrismaClient`
-yields exactly the base types (identical to the default `PrismaService`) and an
-extended client yields its extended types.
+The tag's runtime key defaults to `"PrismaService"` (the same as the built-in
+service) — use one of the two, or pass a distinct key
+(`definePrismaService<typeof prisma>("MyDb")`) if an app needs several
+client-typed services at once.
+
+Under the hood this wraps `makePrismaService(client)` — also exported if you
+want to build the operations object and manage the tag yourself. Both are
+generic over the client type, so a plain `PrismaClient` yields exactly the base
+types (identical to the default `PrismaService`) and an extended client yields
+its extended types, transactions included.
 
 `PrismaClientService` stays typed as `PrismaClient`, so lifecycle methods
 remain available through the service — `$connect()`, `$disconnect()`, and

--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ const program = Effect.gen(function* () {
 });
 ```
 
-The tag's runtime key defaults to `"PrismaService"` (the same as the built-in
-service) — use one of the two, or pass a distinct key
-(`definePrismaService<typeof prisma>("MyDb")`) if an app needs several
-client-typed services at once.
+The tag's runtime key defaults to `"effect-prisma-generator/PrismaService"`,
+which is distinct from the built-in service's key, so both can coexist. Pass
+your own key (`definePrismaService<typeof prisma>("MyDb")`) if an app needs
+several client-typed services at once.
 
 Under the hood this wraps `makePrismaService(client)` — also exported if you
 want to build the operations object and manage the tag yourself. Both are

--- a/src/index.ts
+++ b/src/index.ts
@@ -314,6 +314,10 @@ function variantsFor(major: EffectMajor) {
         `import { Service } from "effect/Effect"`,
       tag: (self: string, type: string, id: string = self) =>
         `Context.Tag("${id}")<\n  ${self},\n  ${type}\n>()`,
+      // A tag whose runtime identity comes from a value (not a literal), for
+      // the user-instantiated definePrismaService factory.
+      tagWithRuntimeKey: (self: string, type: string, keyExpr: string) =>
+        `Context.Tag(${keyExpr})<${self}, ${type}>()`,
       serviceConstructor: `Service<PrismaService>()`,
       serviceConfigKey: "effect",
       txContextVar: "runtime",
@@ -327,6 +331,8 @@ function variantsFor(major: EffectMajor) {
     imports: `import { Cause, Context, Data, Effect, Exit, Layer, Option } from "effect"`,
     tag: (self: string, type: string, id: string = self) =>
       `Context.Service<\n  ${self},\n  ${type}\n>()("${id}")`,
+    tagWithRuntimeKey: (self: string, type: string, keyExpr: string) =>
+      `Context.Service<${self}, ${type}>()(${keyExpr})`,
     serviceConstructor: `Context.Service<PrismaService>()`,
     serviceConfigKey: "make",
     txContextVar: "services",
@@ -857,6 +863,28 @@ export class PrismaService extends ${v.serviceConstructor}("PrismaService", {
     return makePrismaService(client);
   })
 }) {${v.serviceStatics}
+}
+
+// Defines a service tag + layer builder for a specific client type, so an
+// extended client's types flow through the service in one step:
+//
+//   const { service: Db, layer } = definePrismaService<typeof myClient>()
+//   const DbLayer = layer(myClient)
+//   // ... yield* Db  ->  operations typed against myClient (extensions included)
+//
+// \`key\` is the tag's runtime identity; it defaults to "PrismaService" (the
+// same as the built-in service above). Use one of the two, or pass a distinct
+// key if an app needs several client-typed services at once.
+export const definePrismaService = <TClient extends ExtendedPrismaClientLike>(
+  key: string = "PrismaService",
+) => {
+  type Operations = ReturnType<typeof makePrismaService<TClient>>
+  class PrismaServiceTag extends ${v.tagWithRuntimeKey("PrismaServiceTag", "Operations", "key")} {}
+  return {
+    service: PrismaServiceTag,
+    layer: (client: TClient) =>
+      Layer.succeed(PrismaServiceTag, makePrismaService(client)),
+  }
 }
 `;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,20 +220,21 @@ function generateModelOperations(
       const hasOp = (...keys: string[]) =>
         keys.some((key) => Boolean(mapping[key]));
 
-      // Operations are typed with Prisma.Args / Prisma.Result over the
-      // concrete client — the extension-author utilities that resolve for any
-      // delegate. SelectSubset keeps excess-property strictness even for
+      // Operations are typed with Prisma.Args / Prisma.Result over the caller's
+      // own client type TClient — the extension-author utilities that resolve
+      // for any delegate, so an extended client's result extensions and args
+      // flow through. SelectSubset keeps excess-property strictness even for
       // widened non-literal args (Prisma.Exact does not — pinned in
-      // tests/typelevel.test.ts). The delegate call needs the cast because
-      // with a free generic A the delegate's own generics don't bind to A —
-      // the declared Result<> return is what consumers infer from;
-      // tests/typelevel.test.ts pins those shapes and the integration tests
-      // cover runtime behavior.
+      // tests/typelevel.test.ts). The delegate call routes through the loose
+      // view (method names stay checked) and casts the arg, because with a free
+      // TClient the delegate's own generics don't bind to A — the declared
+      // Result<> return is what consumers infer from; tests/typelevel.test.ts
+      // pins those shapes and the integration tests cover runtime behavior.
       const emitOperation = (operationName: string, errorMapper: string) => `
-      ${operationName}: <A extends Prisma.Args<PrismaClient["${modelNameCamel}"], "${operationName}">>(args: Prisma.SelectSubset<A, Prisma.Args<PrismaClient["${modelNameCamel}"], "${operationName}">>) =>
+      ${operationName}: <A extends Prisma.Args<TClient["${modelNameCamel}"], "${operationName}">>(args: Prisma.SelectSubset<A, Prisma.Args<TClient["${modelNameCamel}"], "${operationName}">>) =>
         Effect.flatMap(clientOrTx(client), client =>
           Effect.tryPromise({
-            try: (): Promise<Prisma.Result<PrismaClient["${modelNameCamel}"], A, "${operationName}">> => client.${modelNameCamel}.${operationName}(args),
+            try: (): Promise<Prisma.Result<TClient["${modelNameCamel}"], A, "${operationName}">> => client.${modelNameCamel}.${operationName}(args as never),
             catch: (error) => ${errorMapper}(error, "${operationName}", "${modelName}")
           }),
         ),
@@ -294,7 +295,7 @@ ${operations}
       ) =>
         Effect.flatMap(clientOrTx(client), client =>
           Effect.tryPromise({
-            try: (): Promise<Prisma.Result<PrismaClient["${modelNameCamel}"], T, "groupBy">> => client.${modelNameCamel}.groupBy(args),
+            try: (): Promise<Prisma.Result<TClient["${modelNameCamel}"], T, "groupBy">> => client.${modelNameCamel}.groupBy(args as never),
             catch: (error) => mapFindError(error, "groupBy", "${modelName}")
           }),
         ),
@@ -756,7 +757,7 @@ type LooseDelegates = {
       }
 }
 
-const clientOrTx = (client: PrismaClient) => Effect.map(
+const clientOrTx = (client: ExtendedPrismaClientLike) => Effect.map(
   Effect.serviceOption(PrismaTransactionClientService),
   (tx) => Option.getOrElse(tx, () => client) as unknown as LooseDelegates,
 );
@@ -809,42 +810,51 @@ type GroupByInputErrors<T extends { by?: unknown; orderBy?: unknown; having?: un
   ? {}
   : GroupByOrderByErrors<T>
 
+// Builds the service operations over any client of this schema. Generic over
+// the client type, so providing an extended client (client.$extends(...))
+// yields methods whose args and results reflect the extension. The default
+// PrismaService below instantiates it at PrismaClient; extended-client users
+// instantiate it at their own \`typeof client\` (see the README).
+export const makePrismaService = <TClient extends ExtendedPrismaClientLike>(
+  client: TClient,
+) => ({
+  $transaction: <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+    options?: {
+      maxWait?: number
+      timeout?: number
+      isolationLevel?: Prisma.TransactionIsolationLevel
+    }
+  ) =>
+    Effect.gen(function* () {
+      const ${v.txContextVar} = yield* ${v.txContextExpr};
+      const tx = yield* Effect.serviceOption(PrismaTransactionClientService);
+      return yield* Option.match(tx, {
+        onSome: (tx) => effect,
+        onNone: () =>  Effect.tryPromise({
+          try: () =>
+            client.$transaction(async (tx: Prisma.TransactionClient) => {
+              const exit = await ${v.txRun}(
+                effect.pipe(Effect.provideService(PrismaTransactionClientService, tx)) as Effect.Effect<A, E, R>,
+              )
+              if (Exit.isSuccess(exit)) {
+                return exit.value
+              }
+              throw Cause.squash(exit.cause)
+            }, options),
+          catch: (error) => error as E,
+        }) as unknown as Effect.Effect<A, E, R>,
+      })
+    }),
+  ${rawSqlOperations}
+
+  ${modelOperations}
+})
+
 export class PrismaService extends ${v.serviceConstructor}("PrismaService", {
   ${v.serviceConfigKey}: Effect.gen(function* () {
     const client = yield* PrismaClientService;
-    return {
-      $transaction: <A, E, R>(
-        effect: Effect.Effect<A, E, R>,
-        options?: {
-          maxWait?: number
-          timeout?: number
-          isolationLevel?: Prisma.TransactionIsolationLevel
-        }
-      ) =>
-        Effect.gen(function* () {
-          const ${v.txContextVar} = yield* ${v.txContextExpr};
-          const tx = yield* Effect.serviceOption(PrismaTransactionClientService);
-          return yield* Option.match(tx, {
-            onSome: (tx) => effect,
-            onNone: () =>  Effect.tryPromise({
-              try: () =>
-                client.$transaction(async (tx) => {
-                  const exit = await ${v.txRun}(
-                    effect.pipe(Effect.provideService(PrismaTransactionClientService, tx)) as Effect.Effect<A, E, R>,
-                  )
-                  if (Exit.isSuccess(exit)) {
-                    return exit.value
-                  }
-                  throw Cause.squash(exit.cause)
-                }, options),
-              catch: (error) => error as E,
-            }) as unknown as Effect.Effect<A, E, R>,
-          })
-        }),
-      ${rawSqlOperations}
-
-      ${modelOperations}
-    }
+    return makePrismaService(client);
   })
 }) {${v.serviceStatics}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,15 +210,21 @@ function generateModelOperations(
     .map((model) => {
       const modelName = model.name;
       const modelNameCamel = toCamelCase(modelName);
-      // A model with a required `Unsupported(...)` field (e.g. a pgvector
-      // `vector` column) cannot be created through the typed client, so Prisma
-      // omits its create/createMany/createManyAndReturn/upsert operations and
-      // their `*Args` types. Emit each operation only when its DMMF mapping
-      // exists; Prisma 7 names the single-record mappings `createOne`/
-      // `upsertOne`, older majors used `create`/`upsert`.
+      // Prisma omits an operation's DMMF mapping (and its `*Args` types) when
+      // a model or provider can't support it — e.g. no create-family
+      // operations on a model with a required `Unsupported(...)` field. Emit
+      // each operation only when its mapping exists — otherwise Prisma.Args
+      // would resolve to `any`, silently exposing an untyped method that
+      // fails at runtime. Mapping keys are the operation name, except that
+      // single-record operations carry a "One" suffix on current majors
+      // (`createOne`; older majors used the plain name) and `count` has no
+      // mapping of its own — it exists whenever `aggregate` does.
       const mapping = mappingByModel.get(modelName) ?? {};
-      const hasOp = (...keys: string[]) =>
-        keys.some((key) => Boolean(mapping[key]));
+      const hasOperation = (operationName: string) => {
+        const mappingKey =
+          operationName === "count" ? "aggregate" : operationName;
+        return Boolean(mapping[mappingKey] ?? mapping[`${mappingKey}One`]);
+      };
 
       // Operations are typed with Prisma.Args / Prisma.Result over the caller's
       // own client type TClient — the extension-author utilities that resolve
@@ -240,58 +246,31 @@ function generateModelOperations(
         ),
 `;
 
-      // `gatedOn` lists the operation's DMMF mapping keys: Prisma omits some
-      // operations for some models or providers (a required Unsupported()
-      // field, or a provider without the operation), so a gated operation is
-      // emitted only when one of its mapping keys exists — otherwise
-      // Prisma.Args would resolve to `any`, silently exposing an untyped
-      // method that fails at runtime.
       const operationDefinitions: Array<{
         name: string;
         errorMapper: string;
-        gatedOn?: string[];
       }> = [
         { name: "findUnique", errorMapper: "mapFindError" },
         { name: "findUniqueOrThrow", errorMapper: "mapFindOrThrowError" },
         { name: "findFirst", errorMapper: "mapFindError" },
         { name: "findFirstOrThrow", errorMapper: "mapFindOrThrowError" },
         { name: "findMany", errorMapper: "mapFindError" },
-        {
-          name: "create",
-          errorMapper: "mapCreateError",
-          gatedOn: ["createOne", "create"],
-        },
-        {
-          name: "createMany",
-          errorMapper: "mapCreateError",
-          gatedOn: ["createMany"],
-        },
-        {
-          name: "createManyAndReturn",
-          errorMapper: "mapCreateError",
-          gatedOn: ["createManyAndReturn"],
-        },
+        { name: "create", errorMapper: "mapCreateError" },
+        { name: "createMany", errorMapper: "mapCreateError" },
+        { name: "createManyAndReturn", errorMapper: "mapCreateError" },
         { name: "delete", errorMapper: "mapDeleteError" },
         { name: "update", errorMapper: "mapUpdateError" },
         { name: "deleteMany", errorMapper: "mapDeleteManyError" },
         { name: "updateMany", errorMapper: "mapUpdateManyError" },
-        {
-          name: "updateManyAndReturn",
-          errorMapper: "mapUpdateManyError",
-          gatedOn: ["updateManyAndReturn"],
-        },
-        {
-          name: "upsert",
-          errorMapper: "mapCreateError",
-          gatedOn: ["upsertOne", "upsert"],
-        },
+        { name: "updateManyAndReturn", errorMapper: "mapUpdateManyError" },
+        { name: "upsert", errorMapper: "mapCreateError" },
         { name: "count", errorMapper: "mapFindError" },
         { name: "aggregate", errorMapper: "mapFindError" },
       ];
 
       const operations = operationDefinitions
         .map((operation) =>
-          !operation.gatedOn || hasOp(...operation.gatedOn)
+          hasOperation(operation.name)
             ? emitOperation(operation.name, operation.errorMapper)
             : "",
         )

--- a/src/index.ts
+++ b/src/index.ts
@@ -308,16 +308,17 @@ ${operations}
 // rest of the generated file is identical across majors.
 function variantsFor(major: EffectMajor) {
   if (major === 3) {
+    // The key is an expression so definePrismaService can pass its runtime
+    // `key` parameter; module-level tags pass their name as a string literal.
+    const tagWithRuntimeKey = (self: string, type: string, keyExpr: string) =>
+      `Context.Tag(${keyExpr})<${self}, ${type}>()`;
     return {
       imports:
         `import { Cause, Context, Data, Effect, Exit, Layer, Option, Runtime } from "effect"\n` +
         `import { Service } from "effect/Effect"`,
       tag: (self: string, type: string, id: string = self) =>
-        `Context.Tag("${id}")<\n  ${self},\n  ${type}\n>()`,
-      // A tag whose runtime identity comes from a value (not a literal), for
-      // the user-instantiated definePrismaService factory.
-      tagWithRuntimeKey: (self: string, type: string, keyExpr: string) =>
-        `Context.Tag(${keyExpr})<${self}, ${type}>()`,
+        tagWithRuntimeKey(self, type, `"${id}"`),
+      tagWithRuntimeKey,
       serviceConstructor: `Service<PrismaService>()`,
       serviceConfigKey: "effect",
       txContextVar: "runtime",
@@ -327,12 +328,13 @@ function variantsFor(major: EffectMajor) {
       serviceStatics: "",
     };
   }
+  const tagWithRuntimeKey = (self: string, type: string, keyExpr: string) =>
+    `Context.Service<${self}, ${type}>()(${keyExpr})`;
   return {
     imports: `import { Cause, Context, Data, Effect, Exit, Layer, Option } from "effect"`,
     tag: (self: string, type: string, id: string = self) =>
-      `Context.Service<\n  ${self},\n  ${type}\n>()("${id}")`,
-    tagWithRuntimeKey: (self: string, type: string, keyExpr: string) =>
-      `Context.Service<${self}, ${type}>()(${keyExpr})`,
+      tagWithRuntimeKey(self, type, `"${id}"`),
+    tagWithRuntimeKey,
     serviceConstructor: `Context.Service<PrismaService>()`,
     serviceConfigKey: "make",
     txContextVar: "services",

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,46 +240,62 @@ function generateModelOperations(
         ),
 `;
 
-      // create/createMany/createManyAndReturn/upsert/updateManyAndReturn are
-      // omitted by Prisma for some models or providers (a required
-      // Unsupported() field, or a provider without the operation). Emit each
-      // only when its DMMF mapping exists — otherwise Prisma.Args would resolve
-      // to `any`, silently exposing an untyped method that fails at runtime.
-      const createOperation = hasOp("createOne", "create")
-        ? emitOperation("create", "mapCreateError")
-        : "";
-      const createManyOperation = hasOp("createMany")
-        ? emitOperation("createMany", "mapCreateError")
-        : "";
-      const createManyAndReturnOperation = hasOp("createManyAndReturn")
-        ? emitOperation("createManyAndReturn", "mapCreateError")
-        : "";
-      const upsertOperation = hasOp("upsertOne", "upsert")
-        ? emitOperation("upsert", "mapCreateError")
-        : "";
-      const updateManyAndReturnOperation = hasOp("updateManyAndReturn")
-        ? emitOperation("updateManyAndReturn", "mapUpdateManyError")
-        : "";
+      // `gatedOn` lists the operation's DMMF mapping keys: Prisma omits some
+      // operations for some models or providers (a required Unsupported()
+      // field, or a provider without the operation), so a gated operation is
+      // emitted only when one of its mapping keys exists — otherwise
+      // Prisma.Args would resolve to `any`, silently exposing an untyped
+      // method that fails at runtime.
+      const operationDefinitions: Array<{
+        name: string;
+        errorMapper: string;
+        gatedOn?: string[];
+      }> = [
+        { name: "findUnique", errorMapper: "mapFindError" },
+        { name: "findUniqueOrThrow", errorMapper: "mapFindOrThrowError" },
+        { name: "findFirst", errorMapper: "mapFindError" },
+        { name: "findFirstOrThrow", errorMapper: "mapFindOrThrowError" },
+        { name: "findMany", errorMapper: "mapFindError" },
+        {
+          name: "create",
+          errorMapper: "mapCreateError",
+          gatedOn: ["createOne", "create"],
+        },
+        {
+          name: "createMany",
+          errorMapper: "mapCreateError",
+          gatedOn: ["createMany"],
+        },
+        {
+          name: "createManyAndReturn",
+          errorMapper: "mapCreateError",
+          gatedOn: ["createManyAndReturn"],
+        },
+        { name: "delete", errorMapper: "mapDeleteError" },
+        { name: "update", errorMapper: "mapUpdateError" },
+        { name: "deleteMany", errorMapper: "mapDeleteManyError" },
+        { name: "updateMany", errorMapper: "mapUpdateManyError" },
+        {
+          name: "updateManyAndReturn",
+          errorMapper: "mapUpdateManyError",
+          gatedOn: ["updateManyAndReturn"],
+        },
+        {
+          name: "upsert",
+          errorMapper: "mapCreateError",
+          gatedOn: ["upsertOne", "upsert"],
+        },
+        { name: "count", errorMapper: "mapFindError" },
+        { name: "aggregate", errorMapper: "mapFindError" },
+      ];
 
-      const operations = [
-        emitOperation("findUnique", "mapFindError"),
-        emitOperation("findUniqueOrThrow", "mapFindOrThrowError"),
-        emitOperation("findFirst", "mapFindError"),
-        emitOperation("findFirstOrThrow", "mapFindOrThrowError"),
-        emitOperation("findMany", "mapFindError"),
-        createOperation,
-        createManyOperation,
-        createManyAndReturnOperation,
-        emitOperation("delete", "mapDeleteError"),
-        emitOperation("update", "mapUpdateError"),
-        emitOperation("deleteMany", "mapDeleteManyError"),
-        emitOperation("updateMany", "mapUpdateManyError"),
-        updateManyAndReturnOperation,
-        upsertOperation,
-        "\n      // Aggregation operations\n",
-        emitOperation("count", "mapFindError"),
-        emitOperation("aggregate", "mapFindError"),
-      ].join("");
+      const operations = operationDefinitions
+        .map((operation) =>
+          !operation.gatedOn || hasOp(...operation.gatedOn)
+            ? emitOperation(operation.name, operation.errorMapper)
+            : "",
+        )
+        .join("");
 
       return `    ${modelNameCamel}: {
 ${operations}
@@ -874,11 +890,12 @@ export class PrismaService extends ${v.serviceConstructor}("PrismaService", {
 //   const DbLayer = layer(myClient)
 //   // ... yield* Db  ->  operations typed against myClient (extensions included)
 //
-// \`key\` is the tag's runtime identity; it defaults to "PrismaService" (the
-// same as the built-in service above). Use one of the two, or pass a distinct
-// key if an app needs several client-typed services at once.
+// \`key\` is the tag's runtime identity — tags with equal keys occupy the same
+// context slot. The default is package-namespaced so it cannot collide with
+// the built-in PrismaService or with app-level tags; pass a distinct key if an
+// app needs several client-typed services at once.
 export const definePrismaService = <TClient extends ExtendedPrismaClientLike>(
-  key: string = "PrismaService",
+  key: string = "effect-prisma-generator/PrismaService",
 ) => {
   type Operations = ReturnType<typeof makePrismaService<TClient>>
   class PrismaServiceTag extends ${v.tagWithRuntimeKey("PrismaServiceTag", "Operations", "key")} {}

--- a/tests/fidelity.test.ts
+++ b/tests/fidelity.test.ts
@@ -7,7 +7,10 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { Effect } from "effect";
 import { PrismaClient } from "./prisma/generated/client";
-import { makePrismaService } from "./prisma/generated/effect";
+import {
+  definePrismaService,
+  makePrismaService,
+} from "./prisma/generated/effect";
 
 type Ok<E> = E extends Effect.Effect<infer A, any, any> ? A : never;
 
@@ -56,6 +59,18 @@ const _typeAssertions = () => {
     id: number;
     email: string;
     name: string | null;
+  } | null>();
+
+  // definePrismaService: the ergonomic front door carries the same fidelity —
+  // yielding the tag gives operations typed against the client it was defined
+  // for, extension fields included.
+  const { service: Db, layer } = definePrismaService<typeof extended>();
+  const program = Effect.gen(function* () {
+    const db = yield* Db;
+    return yield* db.user.findFirst({ select: { upperEmail: true } });
+  }).pipe(Effect.provide(layer(extended)));
+  expectTypeOf<Ok<typeof program>>().branded.toEqualTypeOf<{
+    upperEmail: string;
   } | null>();
 };
 

--- a/tests/fidelity.test.ts
+++ b/tests/fidelity.test.ts
@@ -1,0 +1,66 @@
+// Type-level contract for extended-client fidelity: providing a client built
+// with client.$extends(...) to makePrismaService must yield methods whose
+// results reflect the extension. Enforced by the suite's `tsc --noEmit`; the
+// vitest run only confirms the file executes.
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any --
+   type-level assertions produce type-only values and infer through any */
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { Effect } from "effect";
+import { PrismaClient } from "./prisma/generated/client";
+import { makePrismaService } from "./prisma/generated/effect";
+
+type Ok<E> = E extends Effect.Effect<infer A, any, any> ? A : never;
+
+declare const base: PrismaClient;
+
+// Never executed — the assertions are checked by tsc, not at runtime.
+const _typeAssertions = () => {
+  // A result extension adding a computed field to User.
+  const extended = base.$extends({
+    result: {
+      user: {
+        upperEmail: {
+          needs: { email: true },
+          compute: (user) => user.email.toUpperCase(),
+        },
+      },
+    },
+  });
+
+  const extendedService = makePrismaService(extended);
+  const plainService = makePrismaService(base);
+
+  // The extension's computed field is selectable and flows through to the
+  // result, alongside the model's own scalars.
+  const withComputed = extendedService.user.findFirst({
+    select: { upperEmail: true, name: true },
+  });
+  expectTypeOf<Ok<typeof withComputed>>().branded.toEqualTypeOf<{
+    upperEmail: string;
+    name: string | null;
+  } | null>();
+
+  // The extended field is also present when selecting the whole row.
+  const wholeRow = extendedService.user.findFirst({ where: { id: 1 } });
+  expectTypeOf<Ok<typeof wholeRow>>().branded.toEqualTypeOf<{
+    id: number;
+    email: string;
+    name: string | null;
+    upperEmail: string;
+  } | null>();
+
+  // Instantiated at a plain PrismaClient, the same factory yields exactly the
+  // base types — no extension field leaks in.
+  const plain = plainService.user.findFirst({ where: { id: 1 } });
+  expectTypeOf<Ok<typeof plain>>().branded.toEqualTypeOf<{
+    id: number;
+    email: string;
+    name: string | null;
+  } | null>();
+};
+
+describe("extended-client fidelity contract", () => {
+  it("compiles (assertions are enforced by tsc --noEmit)", () => {
+    expect(typeof _typeAssertions).toBe("function");
+  });
+});

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -5,6 +5,7 @@ import * as fs from "fs";
 import { PrismaClient } from "./prisma/generated/client";
 import {
   layerFromPrismaClient,
+  makePrismaService,
   PrismaClientService,
   PrismaService,
   PrismaTransactionClientService,
@@ -443,6 +444,48 @@ describe("Prisma Effect Generator", () => {
         ),
       ),
     ),
+  );
+
+  it.effect(
+    "should apply an extended client's result extension through makePrismaService, including inside a transaction",
+    () =>
+      Effect.gen(function* () {
+        const extended = prisma.$extends({
+          result: {
+            user: {
+              upperEmail: {
+                needs: { email: true },
+                compute: (user) => user.email.toUpperCase(),
+              },
+            },
+          },
+        });
+        const db = makePrismaService(extended);
+        const email = `fidelity-${Date.now()}@example.com`;
+
+        yield* db.user.create({ data: { email, name: "Fidelity" } });
+
+        // Outside a transaction: the computed field is applied at runtime and
+        // its type is present (no cast needed to read it).
+        const outside = yield* db.user.findUniqueOrThrow({
+          where: { email },
+          select: { upperEmail: true },
+        });
+        expect(outside.upperEmail).toBe(email.toUpperCase());
+
+        // Inside a transaction the extension still applies — the extended
+        // client propagates its extensions into the transaction callback, so
+        // the TClient-fidelity return type is honest inside transactions too.
+        const inside = yield* db.$transaction(
+          db.user.findUniqueOrThrow({
+            where: { email },
+            select: { upperEmail: true },
+          }),
+        );
+        expect(inside.upperEmail).toBe(email.toUpperCase());
+
+        yield* db.user.delete({ where: { email } });
+      }),
   );
 
   it("should reject clients missing this schema's model delegates at compile time", () => {


### PR DESCRIPTION
Delivers the v1 client-compat goal: a user's **actual** client — plain or `$extends`-ed — works through the service with its real types (result-extension fields, extension args), transactions included.

## What it adds

- **`makePrismaService<TClient>(client)`** — the service operations, generic over the caller's client type. Providing a `client.$extends(...)` yields methods whose args and results reflect the extension.
- **`definePrismaService<TClient>()`** — the ergonomic front door: builds a service tag + layer for a specific client type in one step, so no hand-rolled tag:
  ```ts
  const { service: Db, layer } = definePrismaService<typeof client>()
  const DbLayer = layer(client)   // yield* Db  ->  operations typed against client
  ```
  Runtime key defaults to `"PrismaService"`; pass a distinct key for multiple client-typed services.

## Backward compatible

`PrismaService` is unchanged — it instantiates `makePrismaService` at `PrismaClient`, so plain-client types and the public API stay identical. Verified against a production 27-model schema: zero type errors.

## Fidelity is complete, transactions included

The runtime spike confirmed extensions apply **inside `$transaction`** too (the extended client propagates its extensions into the transaction callback), so no separate transaction-fidelity work is needed — locked in with a runtime test.

## Checking tradeoff (small)

The generic body routes delegate calls through the loose view and casts only the *argument*, so method names stay checked (typo'd op = compile error, sabotage-verified) while the arg type is carried by the declared `Result<>` return. Consumer-facing arg checking is unchanged (`SelectSubset` over `Prisma.Args<TClient>`); runtime behavior is covered by integration tests.

## Tests

- `tests/fidelity.test.ts` (type-level): an extension's computed field flows through both `makePrismaService` and `definePrismaService`, and a plain client yields exactly the base types — enforced by `tsc --noEmit`, bite-verified.
- `integration.test.ts` (runtime): the computed field is actually applied, outside and inside a transaction.

README documents `definePrismaService` as the recommended path with `makePrismaService` as the lower-level primitive. Works on both effect majors.

Suite 22/22 on both effect legs.