### PR TITLE
feat: expose model field references on the service

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,20 @@ const program = Effect.gen(function* () {
 
 The generated `PrismaService` mirrors your Prisma Client API but returns `Effect<SpecificPrismaResultType, PrismaError, never>` instead of Promises, where `PrismaError` is a specific union type based on the operation (e.g., `PrismaCreateError`, `PrismaUpdateError`, `PrismaFindError`).
 
+### Field References
+
+Each model exposes Prisma's `fields` markers, so a filter can compare two columns of the same model instead of dropping to `$queryRaw`:
+
+```typescript
+const staleAbsences = Effect.gen(function* () {
+  const prisma = yield* PrismaService;
+
+  return yield* prisma.absence.findMany({
+    where: { updatedAt: { gt: prisma.absence.fields.reconciledAt } },
+  });
+});
+```
+
 ### Error Handling
 
 All operations return an `Effect` that can fail with specific Prisma errors. The generator maps Prisma's error codes to typed Effect errors.

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,7 +280,13 @@ function generateModelOperations(
         emitOperation("aggregate", "mapFindError"),
       ].join("");
 
+      // Field references (client.<model>.fields) are inert markers used to
+      // compare two columns of the same model in a filter; they touch no
+      // connection, so they pass through as a plain value rather than an
+      // Effect. Reading them off the base client is correct even inside a
+      // transaction — a transaction client carries the identical refs.
       return `    ${modelNameCamel}: {
+      fields: client.${modelNameCamel}.fields,
 ${operations}
       // groupBy's input validation (having/orderBy fields must appear in "by")
       // is expressed by the shared GroupBy* helpers, since Prisma.Args cannot

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,8 @@ function generateModelOperations(
       // compare two columns of the same model in a filter; they touch no
       // connection, so they pass through as a plain value rather than an
       // Effect. Reading them off the base client is correct even inside a
-      // transaction — a transaction client carries the identical refs.
+      // transaction: a ref only names a column, and a transaction client's own
+      // refs are equivalent values (separate objects, same contents).
       return `    ${modelNameCamel}: {
       fields: client.${modelNameCamel}.fields,
 ${operations}

--- a/src/index.ts
+++ b/src/index.ts
@@ -286,8 +286,11 @@ function generateModelOperations(
       // Effect. Reading them off the base client is correct even inside a
       // transaction: a ref only names a column, and a transaction client's own
       // refs are equivalent values (separate objects, same contents).
+      // A getter, not a property: a property would touch every model delegate
+      // while building the layer, which breaks partial test doubles that only
+      // stub the models they use.
       return `    ${modelNameCamel}: {
-      fields: client.${modelNameCamel}.fields,
+      get fields(): typeof client.${modelNameCamel}.fields { return client.${modelNameCamel}.fields },
 ${operations}
       // groupBy's input validation (having/orderBy fields must appear in "by")
       // is expressed by the shared GroupBy* helpers, since Prisma.Args cannot

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -478,6 +478,31 @@ describe("Prisma Effect Generator", () => {
     ),
   );
 
+  it.effect("should not touch delegates while building the layer", () =>
+    Effect.gen(function* () {
+      const service = yield* PrismaService;
+      const users = yield* service.user.findMany({});
+      expect(users).toEqual([{ id: 1, email: "a@b.c", name: null }]);
+    }).pipe(
+      Effect.provide(
+        Layer.provide(
+          serviceLayer,
+          // Test doubles usually stub only the models under test, so building
+          // the service must read nothing off the client — `fields` is a
+          // getter for exactly this reason.
+          layerFromPrismaClient({
+            $transaction: async () => undefined,
+            $queryRaw: async () => undefined,
+            $executeRaw: async () => undefined,
+            user: {
+              findMany: async () => [{ id: 1, email: "a@b.c", name: null }],
+            },
+          } as unknown as PrismaClient),
+        ),
+      ),
+    ),
+  );
+
   it("should reject clients missing this schema's model delegates at compile time", () => {
     const wrongShapeClient = {
       $transaction: async () => undefined,

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -163,6 +163,39 @@ describe("Prisma Effect Generator", () => {
     }).pipe(Effect.provide(MainLayer)),
   );
 
+  it.effect("should filter by a field reference", () =>
+    Effect.gen(function* () {
+      const prisma = yield* PrismaService;
+      const marker = `fieldref-${Date.now()}`;
+      const selfNamed = `${marker}-self@example.com`;
+      yield* prisma.user.create({
+        data: { email: selfNamed, name: selfNamed },
+      });
+      yield* prisma.user.create({
+        data: { email: `${marker}-other@example.com`, name: "someone else" },
+      });
+
+      const filter = {
+        email: { startsWith: marker },
+        name: { equals: prisma.user.fields.email },
+      };
+
+      const matches = yield* prisma.user.findMany({ where: filter });
+      expect(matches.map((user) => user.email)).toEqual([selfNamed]);
+
+      // Refs are read off the base client at layer construction; inside a
+      // transaction they must still resolve against the transaction client.
+      const inTransaction = yield* prisma.$transaction(
+        prisma.user.findMany({ where: filter }),
+      );
+      expect(inTransaction.map((user) => user.email)).toEqual([selfNamed]);
+
+      yield* prisma.user.deleteMany({
+        where: { email: { startsWith: marker } },
+      });
+    }).pipe(Effect.provide(MainLayer)),
+  );
+
   it.effect("should support transactions", () =>
     Effect.gen(function* () {
       const prisma = yield* PrismaService;

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -183,8 +183,8 @@ describe("Prisma Effect Generator", () => {
       const matches = yield* prisma.user.findMany({ where: filter });
       expect(matches.map((user) => user.email)).toEqual([selfNamed]);
 
-      // Refs are read off the base client at layer construction; inside a
-      // transaction they must still resolve against the transaction client.
+      // The filter captured a base-client ref; the query below runs on the
+      // transaction client, and the ref must still match there.
       const inTransaction = yield* prisma.$transaction(
         prisma.user.findMany({ where: filter }),
       );

--- a/tests/typelevel.test.ts
+++ b/tests/typelevel.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { Effect } from "effect";
 import { PrismaService } from "./prisma/generated/effect";
+import type { Prisma } from "./prisma/generated/client";
 
 const serviceEffect = Effect.gen(function* () {
   return yield* PrismaService;
@@ -231,6 +232,15 @@ const _typeAssertions = () => {
   const widenedArgs = { where: { email: "x" }, bogus: true };
   // @ts-expect-error - excess property survives widening
   service.user.findMany(widenedArgs);
+
+  // Field references pass through with the delegate's own type, so a
+  // column-to-column compare type-checks and mismatched types don't.
+  expectTypeOf(service.user.fields).toEqualTypeOf<Prisma.UserFieldRefs>();
+  service.user.findMany({
+    where: { name: { equals: service.user.fields.email } },
+  });
+  // @ts-expect-error - String ref in an Int filter
+  service.user.findMany({ where: { id: { gt: service.user.fields.email } } });
 
   // distinct + orderBy + take don't perturb the result type
   const distinctPosts = service.post.findMany({


### PR DESCRIPTION
## Why

Prisma lets a filter compare two columns of the same model through field references:

```ts
prisma.absence.findMany({
  where: { updatedAt: { gt: prisma.absence.fields.reconciledAt } },
});
```

The markers live on the client delegate (`client.absence.fields`), not in the `Prisma` namespace. The generated service builds each model as a hand-written object of operations and never copies them over, so "changed since the last sync" style queries can't be expressed through the service at all — you drop to `$queryRaw`, and with it lose typed rows and the model/operation error mapping this generator exists for.

## What this does

Emits `fields` as one more key per model, passing the delegate's own refs through:

```ts
absence: {
  get fields(): typeof client.absence.fields { return client.absence.fields },

  findUnique: <A extends ...>(args) => ...,
  // ...
}
```

The raw query becomes a normal `findMany`, with full result typing.

## Design notes

- **Plain value, no `Effect`.** A field ref is an inert marker — `{ modelName, name, typeName, isList, isEnum }`, verified against the Prisma 7 runtime. It never touches the connection, so wrapping it in an Effect would add ceremony and nothing else.
- **A getter, not a property.** A property would read every model delegate while the layer is being built, which crashes any test double that stubs only the models under test (`Cannot read properties of undefined (reading 'fields')`). The getter keeps layer construction from touching the client at all; there's a regression test for it.
- **Base client is correct.** A ref only names a column, and a transaction client's own refs are equivalent values (separate objects, same contents), so no `clientOrTx` is needed. Pinned by an integration test that runs a ref filter inside `$transaction`.
- **Types come for free.** `client.<model>.fields` is already `Prisma.<Model>FieldRefs` and nothing widens it. The `LooseDelegates` comment in the emitted file already claims non-operation members "keep their real types" — this makes that true for the service object too, not just the delegate view.
- **Extended clients** keep `fields` on their delegates after `$extends` (checked at runtime), so `ExtendedPrismaClientLike` needs no change.

## Tests

- `tests/typelevel.test.ts` — pins `service.user.fields` as `Prisma.UserFieldRefs`, checks a `String` ref in a `String` filter compiles, and `@ts-expect-error`s a `String` ref in an `Int` filter.
- `tests/integration.test.ts` — two users, one whose `name` equals its `email`; the field-ref filter returns only that row, both directly and inside `$transaction`. Plus a partial-mock client that would break if `fields` were read eagerly.

Both the default output and the `noCheck = "false"` fixture type-check; full suite green.
